### PR TITLE
feat: GitHub PR作成自動化のためのカスタムチャットモード追加

### DIFF
--- a/.github/chatmodes/github-push.chatmode.md
+++ b/.github/chatmodes/github-push.chatmode.md
@@ -4,7 +4,7 @@ tools: ['run_in_terminal', 'create_file', 'insert_edit_into_file', 'replace_stri
 ---
 ユーザからPull Requestを出すように指示があった場合には以下の手順で進めてください。
 
-<IMPORTANT>Shell Scriptが記載されていますが，これはあくまで誤解なく認識合わせをするためのものなので，あなたが必ずしも実行する必要はありません。また，Shell Scriptに含まれる「TO LLM:」というキーワードはあなたへのメッセージです。ユーザに確認を求めずにあなた自信が判断してください。</IMPORTANT>
+<IMPORTANT>Shell Scriptが記載されていますが，これはあくまで誤解なく認識合わせをするためのものなので，git，GitHubのMCP Serverを使用して同様の内容を実行しても構いません。また，Shell Scriptに含まれる「TO LLM:」というキーワードはあなたへのメッセージです。ユーザに確認を求めずにあなた自信が判断してください。</IMPORTANT>
 
 1. 現在のブランチ名を取得してください。
   ```bash
@@ -68,4 +68,5 @@ tools: ['run_in_terminal', 'create_file', 'insert_edit_into_file', 'replace_stri
   ```
 
 7. GitHubのMCPサーバを使用して，PRを作成してください。PRは.github/pull_request_template.mdにしたがって作成してください。
+
 


### PR DESCRIPTION
## 概要
Pull Request作成を自動化するためのカスタムチャットモードを追加しました。

## 変更内容
- `.github/chatmodes/github-push.chatmode.md` ファイルを追加
- GitHub MCP Serverを使用してPR作成を自動化するワークフローを定義
- ブランチ作成からPR作成までの一連のプロセスを自動化

## 機能
- 現在のブランチがmain/masterの場合の新規ブランチ作成提案
- コミットタイプ（feat/fix/docs等）の自動選択
- GitHub APIを使用したPR作成
- Copilotレビューの自動依頼

## 確認事項
- [ ] チャットモードが正しく動作するか
- [ ] GitHub MCP Serverとの連携が適切に機能するか
- [ ] ドキュメントが分かりやすく記載されているか